### PR TITLE
Add helper script to manage HA resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # add-vmct-to-pve-ha-resources
-Adds all virtual machines (VMs) and containers (CTs) in a Proxmox cluster to an HA group
+
+This repository contains a helper script that adds all virtual machines (VMs)
+and containers (CTs) in a Proxmox VE cluster to a predefined HA group. VMs that
+use passthrough PCI devices are skipped so they remain bound to the node where
+the device is available.
+
+## Usage
+
+Run the following commands on a Proxmox VE host to download and execute the helper script:
+
+```bash
+wget https://raw.githubusercontent.com/open-e/add-vmct-to-pve-ha-resources/main/add-vmct-to-pve-ha-resources.sh \
+    -O /usr/local/sbin/add-vmct-to-pve-ha-resources; \
+chmod +x /usr/local/sbin/add-vmct-to-pve-ha-resources; \
+add-vmct-to-pve-ha-resources
+```
+
+When executed, the script will create the HA group if it does not already exist
+and then add every eligible VM and CT to it. VMs using passthrough devices are
+skipped automatically.

--- a/add-vmct-to-pve-ha-resources.sh
+++ b/add-vmct-to-pve-ha-resources.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# ---- Configuration ---------------------------------------------------------
+# Change GROUP if you want a different HA group name.
+GROUP="powernodes"
+# Adjust these node names if your "power" nodes differ.
+GROUP_NODES="pve1,pve2"
+# ---------------------------------------------------------------------------
+
+# ---- Function: get_vms_with_hostpci ---------------------------------------
+# Search each VM configuration under /etc/pve/nodes/*/qemu-server for lines
+# containing the "hostpci" directive. Any config with that option belongs to a
+# VM that uses PCI passthrough and should not be automatically managed by HA.
+# The function extracts the numeric VMID from every matching filename and
+# returns a sorted list of unique IDs.
+get_vms_with_hostpci() {
+  grep -Rl hostpci /etc/pve/nodes/*/qemu-server/*.conf 2>/dev/null | \
+    sed -E 's#.*/([0-9]+)\.conf#\1#' | sort -u
+}
+# ---------------------------------------------------------------------------
+
+# 1) Install jq if missing
+command -v jq >/dev/null 2>&1 || {
+  echo "jq not found, installing..."
+  apt update && apt install -y jq
+}
+
+# 2) Ensure HA group exists (or create it as a restricted group on GROUP_NODES)
+if ! ha-manager group config "$GROUP" &>/dev/null; then
+  echo "Group '$GROUP' does not exist. Creating restricted group on nodes: $GROUP_NODES"
+  ha-manager groupadd "$GROUP" \
+    --nodes "$GROUP_NODES" \
+    --restricted 1 \
+    --comment "Auto-created by add-vmct-to-pve-ha-resources.sh"
+fi
+
+# 3) Build an array of VMIDs that have hostpci devices
+readarray -t HOSTPCI_VMS < <(get_vms_with_hostpci)
+
+echo "This script will add all VMs and CTs to the HA group '$GROUP'"
+echo "on nodes: $GROUP_NODES. VMs using PCI passthrough will be skipped."
+read -n 1 -s -r -p "Press any key to continue or Ctrl-C to exit" _
+echo
+
+# 4) Loop over every VM/CT in the cluster and add to HA if not using hostpci
+pvesh get /cluster/resources --type vm --output-format=json | \
+  jq -r '
+    .[]
+    | select(.type=="qemu" or .type=="lxc")
+    | (if .type=="qemu" then "vm:" else "ct:" end) + (.vmid | tostring)
+  ' | while read -r sid; do
+      # Parse type ("vm" or "ct") and numeric ID
+      TYPE=${sid%%:*}
+      VMID=${sid#*:}
+
+      # If this is a VM, skip it if its ID appears in HOSTPCI_VMS
+      if [ "$TYPE" = "vm" ]; then
+        for skip_id in "${HOSTPCI_VMS[@]}"; do
+          if [ "$VMID" = "$skip_id" ]; then
+            echo "Skipping vm:$VMID (hostpci present)"
+            continue 2
+          fi
+        done
+      fi
+
+      # Skip if already in HA
+      if ha-manager status | grep -qE "^$sid\b"; then
+        continue
+      fi
+
+      echo "Adding $sid -> HA group \"$GROUP\""
+      ha-manager add "$sid" --state started --group "$GROUP" \
+        --comment "HA ${VMID} on $GROUP_NODES"
+  done
+


### PR DESCRIPTION
## Summary
- add a script to automatically populate the HA group
- describe usage of the script in the README
- add user confirmation prompt

## Testing
- `shellcheck add-vmct-to-pve-ha-resources.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68406de991608325b0b02e1570c4ecc6